### PR TITLE
chore: rollback boto3 to the old version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 install_requires = [
-    'boto3>=1.42.8',
+    'boto3>=1.34.8',
     'certifi>=2025.11.12',
 ]
 


### PR DESCRIPTION
Refer to https://github.com/getsentry/sentry/blob/7302e23cc1495adbc62da4e129cfc6f2243173eb/pyproject.toml#L9-L10

Closes https://github.com/getsentry/self-hosted/issues/4144
